### PR TITLE
Avoid mirroring tiles diagonally.

### DIFF
--- a/pyisotools/bnrparser.py
+++ b/pyisotools/bnrparser.py
@@ -177,8 +177,8 @@ class BNR(RGB5A3):
             for blockColumn in range(BNR.ImgTileWidth):
                 for tileRow in range(BNR.TileHeight):
                     for tileColumn in range(BNR.TileWidth):
-                        column = blockColumn*BNR.TileWidth + tileRow
-                        row = blockRow*BNR.TileHeight + tileColumn
+                        column = blockColumn*BNR.TileWidth + tileColumn
+                        row = blockRow*BNR.TileHeight + tileRow
 
                         pixel = smallImg.getpixel((column, row))
                         if column < BNR.ImageWidth and row < BNR.ImageHeight:
@@ -263,8 +263,8 @@ class BNR(RGB5A3):
             for blockColumn in range(BNR.ImgTileWidth):
                 for tileRow in range(BNR.TileHeight):
                     for tileColumn in range(BNR.TileWidth):
-                        column = blockColumn*BNR.TileWidth + tileRow
-                        row = blockRow*BNR.TileHeight + tileColumn
+                        column = blockColumn*BNR.TileWidth + tileColumn
+                        row = blockRow*BNR.TileHeight + tileRow
 
                         pixel = int.from_bytes(
                             _image.read(2), "big", signed=False)


### PR DESCRIPTION
It seems this was a regression introduced by https://github.com/cristian64/pyisotools/commit/13b6ec354576973689908f3de66856600f9f8115,
where the tile column and the tile row were swapped inadvertently.

Because both the extract and the compile operations were suffering from
the same issue, two bads were making a good, and the resulting BNR file
after exporting/re-compiling was in fact good. However, the transitory
PNG image was corrupted.

Example of a corrupted PNG image:

![image](https://user-images.githubusercontent.com/1853278/167252802-f94822b3-47b2-4609-a4c3-d7f82aa71ff1.png)

Generated with:
```bash
cd pyisotools
python3 -m pyisotools.bnrparser .../GM4E01/files/opening.bnr /tmp/image.png -j EXTRACT
```